### PR TITLE
Prepare Xerces adapter refactoring for #642

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPErrorReporterForXML.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPErrorReporterForXML.java
@@ -19,7 +19,7 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
-import org.eclipse.lemminx.services.extensions.diagnostics.AbstractLSPErrorReporter;
+import org.eclipse.lemminx.services.extensions.xerces.AbstractLSPErrorReporter;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/LSPErrorReporterForXSD.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/LSPErrorReporterForXSD.java
@@ -18,7 +18,7 @@ import org.apache.xerces.xni.XMLLocator;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.xsd.participants.XSDErrorCode;
-import org.eclipse.lemminx.services.extensions.diagnostics.AbstractLSPErrorReporter;
+import org.eclipse.lemminx.services.extensions.xerces.AbstractLSPErrorReporter;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 import org.xml.sax.ErrorHandler;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/xerces/AbstractLSPErrorReporter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/xerces/AbstractLSPErrorReporter.java
@@ -10,9 +10,7 @@
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  */
-package org.eclipse.lemminx.services.extensions.diagnostics;
-
-import static org.eclipse.lemminx.utils.XMLPositionUtility.toLSPPosition;
+package org.eclipse.lemminx.services.extensions.xerces;
 
 import java.util.List;
 
@@ -23,6 +21,8 @@ import org.apache.xerces.util.MessageFormatter;
 import org.apache.xerces.xni.XMLLocator;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLParseException;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -160,4 +160,24 @@ public abstract class AbstractLSPErrorReporter extends XMLErrorReporter {
 	}
 
 	protected abstract Range toLSPRange(XMLLocator location, String key, Object[] arguments, DOMDocument document);
+	
+
+	/**
+	 * Returns the LSP position from the SAX location.
+	 * 
+	 * @param offset   the adjusted offset.
+	 * @param location the original SAX location.
+	 * @param document the text document.
+	 * @return the LSP position from the SAX location.
+	 */
+	private static Position toLSPPosition(int offset, XMLLocator location, TextDocument document) {
+		if (location != null && offset == location.getCharacterOffset() - 1) {
+			return new Position(location.getLineNumber() - 1, location.getColumnNumber() - 1);
+		}
+		try {
+			return document.positionAt(offset);
+		} catch (BadLocationException e) {
+			return location != null ? new Position(location.getLineNumber() - 1, location.getColumnNumber() - 1) : null;
+		}
+	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/xerces/LSPMessageFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/xerces/LSPMessageFormatter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.eclipse.lemminx.services.extensions.diagnostics;
+package org.eclipse.lemminx.services.extensions.xerces;
 
 import static org.eclipse.lemminx.dom.parser.Constants.*;
 import static org.eclipse.lemminx.utils.StringUtils.getString;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
@@ -50,25 +50,6 @@ public class XMLPositionUtility {
 	private XMLPositionUtility() {
 	}
 
-	/**
-	 * Returns the LSP position from the SAX location.
-	 * 
-	 * @param offset   the adjusted offset.
-	 * @param location the original SAX location.
-	 * @param document the text document.
-	 * @return the LSP position from the SAX location.
-	 */
-	public static Position toLSPPosition(int offset, XMLLocator location, TextDocument document) {
-		if (location != null && offset == location.getCharacterOffset() - 1) {
-			return new Position(location.getLineNumber() - 1, location.getColumnNumber() - 1);
-		}
-		try {
-			return document.positionAt(offset);
-		} catch (BadLocationException e) {
-			return location != null ? new Position(location.getLineNumber() - 1, location.getColumnNumber() - 1) : null;
-		}
-	}
-
 	public static Range selectAttributeNameAt(int offset, DOMDocument document) {
 		offset = adjustOffsetForAttribute(offset, document);
 		DOMAttr attr = document.findAttrAt(offset);


### PR DESCRIPTION
* move classes linked to Xerces to the o.e.l.extensions.xerces
* move XMLPositionUtility#toLSPPosition to AbstractLSPErrorReporter

Signed-off-by: Max Hohenegger <eclipse@hohenegger.eu>