### PR TITLE
Remove unnecessary Guava dependencies

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -150,7 +150,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.0.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,39 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.7</version>
+				<version>2.8.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.lsp4j</groupId>
 				<artifactId>org.eclipse.lsp4j</artifactId>
 				<version>${lsp4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>27.0.1-jre</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.google.guava</groupId>
+						<artifactId>listenablefuture</artifactId>
+					  </exclusion>
+					  <exclusion>
+						<groupId>org.checkerframework</groupId>
+						<artifactId>checker-qual</artifactId>
+					  </exclusion>
+					  <exclusion>
+						<groupId>com.google.errorprone</groupId>
+						<artifactId>error_prone_annotations</artifactId>
+					  </exclusion>
+					  <exclusion>
+						<groupId>com.google.j2objc</groupId>
+						<artifactId>j2objc-annotations</artifactId>
+					  </exclusion>
+					  <exclusion>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>animal-sniffer-annotations</artifactId>
+					  </exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.lsp4j</groupId>


### PR DESCRIPTION
According to https://github.com/google/guava#important-warnings:

> Guava has one dependency that is needed at runtime: com.google.guava:failureaccess:1.0.1

Signed-off-by: Fred Bricon <fbricon@gmail.com>