### PR TITLE
Print errors to standard error if flag set

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLServerLauncher.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLServerLauncher.java
@@ -42,6 +42,7 @@ public class XMLServerLauncher {
 		final String HTTP_PROXY_PORT = System.getenv("HTTP_PROXY_PORT");
 		final String HTTP_PROXY_USERNAME = System.getenv("HTTP_PROXY_USERNAME");
 		final String HTTP_PROXY_PASSWORD = System.getenv("HTTP_PROXY_PASSWORD");
+		final boolean LEMMINX_DEBUG = System.getenv("LEMMINX_DEBUG") != null;
 
 		if (HTTP_PROXY_HOST != null && HTTP_PROXY_PORT != null) {
 			System.setProperty("http.proxyHost", HTTP_PROXY_HOST);
@@ -70,7 +71,9 @@ public class XMLServerLauncher {
 		PrintStream out = System.out;
 		System.setIn(new NoOpInputStream());
 		System.setOut(new NoOpPrintStream());
-		System.setErr(new NoOpPrintStream());
+		if (!LEMMINX_DEBUG) {
+			System.setErr(new NoOpPrintStream());
+		}
 		launch(in, out);
 	}
 


### PR DESCRIPTION
If the environment variable `LEMMINX_DEBUG` is set,
then Java's errors will not be disconnected from standard error.

Closes #1019

Signed-off-by: David Thompson <davthomp@redhat.com>