### PR TITLE
Use related information for unclosed elements

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
@@ -49,7 +49,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getNodeType()
 	 */
 	@Override
@@ -59,7 +59,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getNodeName()
 	 */
 	@Override
@@ -69,7 +69,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Element#getTagName()
 	 */
 	@Override
@@ -80,7 +80,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns true if the DOM element have a tag name and false otherwise (ex : '<'
 	 * or '</').
-	 * 
+	 *
 	 * @return true if the DOM element have a tag name and false otherwise (ex : '<'
 	 *         or '</').
 	 */
@@ -90,7 +90,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getLocalName()
 	 */
 	@Override
@@ -108,7 +108,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getPrefix()
 	 */
 	@Override
@@ -127,7 +127,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getNamespaceURI()
 	 */
 	@Override
@@ -139,9 +139,9 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/**
 	 * Returns the namespace URI for the given prefix and null otherwise.
-	 * 
+	 *
 	 * @param prefix the prefix.
-	 * 
+	 *
 	 * @return the namespace URI for the given prefix and null otherwise.
 	 */
 	public String getNamespaceURI(String prefix) {
@@ -167,7 +167,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns the namespace URI from the given prefix declared in the given element
 	 * and null otherwise.
-	 * 
+	 *
 	 * @param prefix  the prefix
 	 * @param element the DOM element
 	 * @return the namespace URI from the given prefix declared in the given element
@@ -193,7 +193,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/**
 	 * Returns the xmlns prefix from the given namespace URI and null otherwise.
-	 * 
+	 *
 	 * @param namespaceURI the namespace
 	 * @return the xmlns prefix from the given namespace URI and null otherwise.
 	 */
@@ -236,9 +236,9 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 * Will traverse backwards from the start offset returning an offset of the
 	 * given character if it's found before another character. Whitespace is
 	 * ignored.
-	 * 
+	 *
 	 * Returns null if the character is not found.
-	 * 
+	 *
 	 * The initial value for the start offset is not included. So have the offset 1
 	 * position after the character you want to start at.
 	 */
@@ -265,7 +265,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns true if the given tag is the same tag of this element and false
 	 * otherwise.
-	 * 
+	 *
 	 * @param tag tag element
 	 * @return true if the given tag is the same tag of this element and false
 	 *         otherwise.
@@ -305,7 +305,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns the start tag open offset and {@link DOMNode#NULL_VALUE} if it
 	 * doesn't exist.
-	 * 
+	 *
 	 * @return the start tag open offset and {@link DOMNode#NULL_VALUE} if it
 	 *         doesn't exist.
 	 */
@@ -316,7 +316,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns the start tag close offset and {@link DOMNode#NULL_VALUE} if it
 	 * doesn't exist.
-	 * 
+	 *
 	 * @return the start tag close offset and {@link DOMNode#NULL_VALUE} if it
 	 *         doesn't exist.
 	 */
@@ -327,7 +327,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns the end tag open offset and {@link DOMNode#NULL_VALUE} if it doesn't
 	 * exist.
-	 * 
+	 *
 	 * @return the end tag open offset and {@link DOMNode#NULL_VALUE} if it doesn't
 	 *         exist.
 	 */
@@ -338,7 +338,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns the end tag close offset and {@link DOMNode#NULL_VALUE} if it doesn't
 	 * exist.
-	 * 
+	 *
 	 * @return the end tag close offset and {@link DOMNode#NULL_VALUE} if it doesn't
 	 *         exist.
 	 */
@@ -348,10 +348,10 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/**
 	 * Returns true if has a start tag.
-	 * 
+	 *
 	 * In our source-oriented DOM, a lone end tag will cause a node to be created in
 	 * the tree, unlike well-formed-only DOMs.
-	 * 
+	 *
 	 * @return true if has a start tag.
 	 */
 	public boolean hasStartTag() {
@@ -360,10 +360,10 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/**
 	 * Returns true if has an end tag.
-	 * 
+	 *
 	 * In our source-oriented DOM, sometimes Elements are "ended", even without an
 	 * explicit end tag in the source.
-	 * 
+	 *
 	 * @return true if has an end tag.
 	 */
 	public boolean hasEndTag() {
@@ -387,7 +387,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns true if the given element is an orphan end tag (which has no start
 	 * tag, eg: </a>) and false otherwise.
-	 * 
+	 *
 	 * @return true if the given element is an orphan end tag (which has no start
 	 *         tag, eg: </a>) and false otherwise.
 	 */
@@ -398,13 +398,32 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns true if the given element is an orphan end tag (which has no start
 	 * tag, eg: </a>) of the given tag name and false otherwise.
-	 * 
+	 *
 	 * @param tagName the end tag name.
 	 * @return true if the given element is an orphan end tag (which has no start
 	 *         tag, eg: </a>) of the given tag name and false otherwise.
 	 */
 	public boolean isOrphanEndTagOf(String tagName) {
 		return isSameTag(tagName) && isOrphanEndTag();
+	}
+
+	/**
+	 * Returns the offset at which the given unclosed start tag should be closed with an angle bracket
+	 *
+	 * @returns the offset at which the given unclosed start tag should be closed with an angle bracket
+	 */
+	public int getUnclosedStartTagCloseOffset() {
+		String documentText = getOwnerDocument().getText();
+		int i = getStart() + 1;
+		for (; i < documentText.length() && documentText.charAt(i) != '/' && documentText.charAt(i) != '<'; i++) {
+		}
+		if (i < documentText.length() && documentText.charAt(i) == '/') {
+			return i + 1;
+		}
+		i--;
+		for (; i > 0 && Character.isWhitespace(documentText.charAt(i)); i--) {
+		}
+		return i + 1;
 	}
 
 	@Override
@@ -436,7 +455,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	/**
 	 * Returns true if element has a closing end tag (eg: <a> </a>) and false
 	 * otherwise (eg: <a> </b>).
-	 * 
+	 *
 	 * @return true if element has a closing end tag (eg: <a> </a>) and false
 	 *         otherwise (eg: <a> </b>).
 	 */
@@ -521,7 +540,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	/**
 	 * Returns true if the element is empty and false otherwise.
-	 * 
+	 *
 	 * @return true if the element is empty and false otherwise.
 	 */
 	public boolean isEmpty() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/AggregateRelatedInfoFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/AggregateRelatedInfoFinder.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lsp4j.DiagnosticRelatedInformation;
+
+/**
+ * Finds related info for any error code
+ */
+public class AggregateRelatedInfoFinder implements IRelatedInfoFinder {
+
+	private static IRelatedInfoFinder[] RELATED_INFO_FINDERS = {
+		new XMLSyntaxRelatedInfoFinder()
+	};
+
+	private static AggregateRelatedInfoFinder INSTANCE = null;
+
+	private AggregateRelatedInfoFinder() {}
+
+	public static AggregateRelatedInfoFinder getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new AggregateRelatedInfoFinder();
+		}
+		return INSTANCE;
+	}
+
+	@Override
+	public List<DiagnosticRelatedInformation> findRelatedInformation(
+			int offset,
+			String errorKey,
+			DOMDocument document) {
+		List<DiagnosticRelatedInformation> relatedInfo = new ArrayList<>();
+		for (IRelatedInfoFinder relatedInfoFinder : RELATED_INFO_FINDERS) {
+			relatedInfo.addAll(relatedInfoFinder.findRelatedInformation(
+				offset,
+				errorKey,
+				document
+			));
+		}
+		return relatedInfo;
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/IRelatedInfoFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/IRelatedInfoFinder.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants;
+
+import java.util.List;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lsp4j.DiagnosticRelatedInformation;
+
+/**
+ * Provides an interface to find related info for a given error
+ */
+public interface IRelatedInfoFinder {
+
+	/**
+	 * Returns a list of related information
+	 *
+	 * @param offset   The LemMinX reported error start offset
+	 * @param errorKey The error key
+	 * @param document The document
+	 * @return a list of related information
+	 */
+	List<DiagnosticRelatedInformation> findRelatedInformation(
+			int offset,
+			String errorKey,
+			DOMDocument document);
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -43,7 +43,7 @@ import org.eclipse.lsp4j.ResourceOperationKind;
 
 /**
  * XML error code.
- * 
+ *
  * @see https://wiki.xmldation.com/Support/Validator
  *
  */
@@ -120,7 +120,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 
 	/**
 	 * Create the LSP range from the SAX error.
-	 * 
+	 *
 	 * @param location
 	 * @param key
 	 * @param arguments
@@ -181,11 +181,11 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 		case ETagUnterminated: {
 			/**
 			 * Cases:
-			 * 
+			 *
 			 * <a> </b>
-			 * 
+			 *
 			 * <a> <b> </b> </c>
-			 * 
+			 *
 			 * <a> <a> </a> </b
 			 */
 			int endOffset = removeLeftSpaces(offset, document.getText());
@@ -218,11 +218,11 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 			// Cases
 			// - <foo
 			// - <foo /
-			DOMNode root = document.getDocumentElement();
-			if (root == null) {
-				root = document.getChild(0);
+			DOMElement documentElement = document.getDocumentElement();
+			if (documentElement != null && documentElement.hasEndTag()) {
+				return XMLPositionUtility.selectEndTagName(documentElement);
 			}
-			return getRangeFromStartNodeToOffset(root, offset, document);
+			return XMLPositionUtility.selectRootStartTag(document);
 		}
 		case ETagRequired: {
 			String tag = getString(arguments[0]);
@@ -241,7 +241,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 					startTagElement = findChildTag(tag, element);
 
 				}
-				return getRangeFromStartNodeToOffset(startTagElement, offset, document);
+				return XMLPositionUtility.selectStartTagName(startTagElement);
 			}
 			// Should never occurs
 			return null;
@@ -311,9 +311,9 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	/**
 	 * Remove the offset of the first character from the left offset which is not a
 	 * whitespace.
-	 * 
+	 *
 	 * @param initialOffset the initial offset.
-	 * 
+	 *
 	 * @param text          the XML content.
 	 * @return the offset of the first character from the left offset which is not a
 	 *         whitespace.
@@ -351,11 +351,11 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 
 	/**
 	 * Returns the proper range from the given node to the given offset.
-	 * 
+	 *
 	 * @param fromNode the from node.
 	 * @param toOffset the to offset.
 	 * @param document the DOM document.
-	 * 
+	 *
 	 * @return the proper range from the given node to the given offset.
 	 */
 	private static Range getRangeFromStartNodeToOffset(DOMNode fromNode, int toOffset, DOMDocument document) {
@@ -376,7 +376,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	/**
 	 * Returns the first child element of the given element which matches the given
 	 * tag name and null otherwise.
-	 * 
+	 *
 	 * @param tagName the tag name.
 	 * @param element the DOM element.
 	 * @return the first child element of the given element which matches the given

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxRelatedInfoFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxRelatedInfoFinder.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.utils.XMLPositionUtility;
+import org.eclipse.lsp4j.DiagnosticRelatedInformation;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Find related information for an XML syntax error
+ */
+public class XMLSyntaxRelatedInfoFinder implements IRelatedInfoFinder {
+
+	private static String CLOSING_TAG_EXPECTED_HERE = "Closing tag expected here";
+
+	@Override
+	public List<DiagnosticRelatedInformation> findRelatedInformation(int offset, String errorKey,
+			DOMDocument document) {
+
+		XMLSyntaxErrorCode syntaxCode = XMLSyntaxErrorCode.get(errorKey);
+
+		if (syntaxCode == null) {
+			return Collections.emptyList();
+		}
+
+		switch (syntaxCode) {
+			case ETagRequired:
+			case MarkupEntityMismatch: {
+			DOMNode node = document.findNodeAt(offset);
+			while (node != null && !node.isElement()) {
+				node = node.getParentNode();
+			}
+			if (node == null) {
+				return Collections.emptyList();
+			}
+
+			if (node == document.getDocumentElement() && ((DOMElement) node).hasEndTag()){
+				return Collections.emptyList();
+			}
+
+			int closeTagOffset;
+			int numChildren = node.getChildren().size();
+			if (numChildren == 0) {
+				closeTagOffset = node.getEnd();
+			} else {
+				closeTagOffset = node.getChildren().get(numChildren - 1).getEnd();
+			}
+
+			Range range = XMLPositionUtility.createRange(closeTagOffset, closeTagOffset, document);
+			return Collections.singletonList(new DiagnosticRelatedInformation(
+					new Location(document.getDocumentURI(), range), CLOSING_TAG_EXPECTED_HERE));
+		}
+		default:
+		}
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPErrorReporterForXML.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPErrorReporterForXML.java
@@ -56,7 +56,7 @@ public class LSPErrorReporterForXML extends AbstractLSPErrorReporter {
 	public LSPErrorReporterForXML(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
 			ContentModelManager contentModelManager, boolean hasRelatedInformation,
 			Map<String, ReferencedGrammarDiagnosticsInfo> referencedGrammarDiagnosticsInfoCache) {
-		super(XML_DIAGNOSTIC_SOURCE, xmlDocument, diagnostics);
+		super(XML_DIAGNOSTIC_SOURCE, xmlDocument, diagnostics, hasRelatedInformation);
 		this.contentModelManager = contentModelManager;
 		this.hasRelatedInformation = hasRelatedInformation;
 		this.referencedGrammarDiagnosticsInfoCache = referencedGrammarDiagnosticsInfoCache == null ? new HashMap<>()
@@ -65,7 +65,7 @@ public class LSPErrorReporterForXML extends AbstractLSPErrorReporter {
 
 	/**
 	 * Create the LSP range from the SAX error.
-	 * 
+	 *
 	 * @param location
 	 * @param key
 	 * @param arguments
@@ -137,7 +137,7 @@ public class LSPErrorReporterForXML extends AbstractLSPErrorReporter {
 	/**
 	 * Create a diagnostic root where XSD, DTD which have the error if needed and
 	 * attach the error as related information if LSP client support it.
-	 * 
+	 *
 	 * @param location                 the Xerces location.
 	 * @param key                      the Xerces error key
 	 * @param arguments                the Xerces error arguments
@@ -191,7 +191,7 @@ public class LSPErrorReporterForXML extends AbstractLSPErrorReporter {
 
 	/**
 	 * Returns the referenced grammar diagnostics info from the given grammar URI.
-	 * 
+	 *
 	 * @param grammarURI               the referenced grammar URI.
 	 * @param resolverExtensionManager the resolver used to load the DOM document of
 	 *                                 the referenced grammar.
@@ -204,7 +204,7 @@ public class LSPErrorReporterForXML extends AbstractLSPErrorReporter {
 			// Create diagnostic where DDT, XSD which have errors is declared
 			Range range = getReferencedGrammarRange(grammarURI);
 			String message = "";
-			Diagnostic diagnostic = super.addDiagnostic(range, message, DiagnosticSeverity.Error, null);
+			Diagnostic diagnostic = super.addDiagnostic(range, message, DiagnosticSeverity.Error, null, null);
 			// Register the diagnostic as root diagnostic for the XSD, DTD grammar uri
 			info = new ReferencedGrammarDiagnosticsInfo(grammarURI, resolverExtensionManager, diagnostic);
 			referencedGrammarDiagnosticsInfoCache.put(grammarURI, info);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPSAXParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/LSPSAXParser.java
@@ -43,7 +43,7 @@ import org.xml.sax.SAXNotSupportedException;
 
 /**
  * Extension of Xerces SAX Parser to fix some Xerces bugs:
- * 
+ *
  * <ul>
  * <li>[BUG 1]: when the DTD file path is wrong on DOCTYPE, Xerces breaks all
  * validation like syntax validation</li>
@@ -51,7 +51,7 @@ import org.xml.sax.SAXNotSupportedException;
  * ignore the existing of entities. See
  * https://github.com/redhat-developer/vscode-xml/issues/234</li>
  * </ul>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -122,7 +122,7 @@ public class LSPSAXParser extends SAXParser {
 					Range range = new Range(document.positionAt(docType.getSystemIdNode().getStart()),
 							document.positionAt(docType.getSystemIdNode().getEnd()));
 					reporter.addDiagnostic(range, MessageFormat.format(DTD_NOT_FOUND, expandedSystemId),
-							DiagnosticSeverity.Error, DTDErrorCode.dtd_not_found.getCode());
+							DiagnosticSeverity.Error, DTDErrorCode.dtd_not_found.getCode(), null);
 				} catch (BadLocationException e) {
 					// Do nothing
 				}
@@ -158,7 +158,7 @@ public class LSPSAXParser extends SAXParser {
 
 	/**
 	 * Create DTD grammar description by expanding the system id.
-	 * 
+	 *
 	 * @param rootElement the root element
 	 * @param publicId    the public ID.
 	 * @param systemId    the system ID.
@@ -178,7 +178,7 @@ public class LSPSAXParser extends SAXParser {
 	 * Resolve the expanded system ID by resolving the system ID of the given
 	 * grammar description with uri resolver (XML catalog, cache, etc with
 	 * {@link URIResolverExtensionManager}).
-	 * 
+	 *
 	 * @param grammarDesc   the DTD grammar description.
 	 * @param entityManager the entity manager.
 	 * @return the expanded system ID by resolving the system ID of the given
@@ -213,7 +213,7 @@ public class LSPSAXParser extends SAXParser {
 
 	/**
 	 * Fill entities from the given DTD grammar to the given entity manager.
-	 * 
+	 *
 	 * @param grammar       the DTD grammar
 	 * @param entityManager the entitymanager to update with entities of the DTD
 	 *                      grammar.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/LSPErrorReporterForXSD.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/LSPErrorReporterForXSD.java
@@ -35,13 +35,13 @@ public class LSPErrorReporterForXSD extends AbstractLSPErrorReporter {
 
 	private static final String XSD_DIAGNOSTIC_SOURCE = "xsd";
 
-	public LSPErrorReporterForXSD(DOMDocument xmlDocument, List<Diagnostic> diagnostics) {
-		super(XSD_DIAGNOSTIC_SOURCE, xmlDocument, diagnostics);
+	public LSPErrorReporterForXSD(DOMDocument xmlDocument, List<Diagnostic> diagnostics, boolean hasRelatedInfo) {
+		super(XSD_DIAGNOSTIC_SOURCE, xmlDocument, diagnostics, hasRelatedInfo);
 	}
 
 	/**
 	 * Create the LSP range from the SAX error.
-	 * 
+	 *
 	 * @param location
 	 * @param key
 	 * @param arguments

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDDiagnosticsParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDDiagnosticsParticipant.java
@@ -39,7 +39,7 @@ public class XSDDiagnosticsParticipant implements IDiagnosticsParticipant {
 		// associations settings., ...)
 		XMLEntityResolver entityResolver = xmlDocument.getResolverExtensionManager();
 		// Process validation
-		XSDValidator.doDiagnostics(xmlDocument, entityResolver, diagnostics, cancelChecker);
+		XSDValidator.doDiagnostics(xmlDocument, entityResolver, diagnostics, validationSettings.isRelatedInformation(), cancelChecker);
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
@@ -46,10 +46,10 @@ public class XSDValidator {
 	private static boolean canCustomizeReporter = true;
 
 	public static void doDiagnostics(DOMDocument document, XMLEntityResolver entityResolver,
-			List<Diagnostic> diagnostics, CancelChecker monitor) {
+			List<Diagnostic> diagnostics, boolean isRelatedInformation, CancelChecker monitor) {
 
 		try {
-			XMLErrorReporter reporter = new LSPErrorReporterForXSD(document, diagnostics);
+			XMLErrorReporter reporter = new LSPErrorReporterForXSD(document, diagnostics, isRelatedInformation);
 
 			XMLGrammarPreparser grammarPreparser = new LSPXMLGrammarPreparser();
 			XMLSchemaLoader schemaLoader = createSchemaLoader(reporter);
@@ -97,7 +97,7 @@ public class XSDValidator {
 
 	/**
 	 * Create the XML Schema loader to use to validate the XML Schema.
-	 * 
+	 *
 	 * @param reporter the lsp reporter.
 	 * @return the XML Schema loader to use to validate the XML Schema.
 	 * @throws NoSuchFieldException

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
@@ -634,7 +634,7 @@ public class DTDDiagnosticsTest {
 		XMLAssert.testDiagnosticsFor(xml, d(1, 29, 1, 46, DTDErrorCode.dtd_not_found), // [1]
 				d(2, 1, 12, DTDErrorCode.MSG_ELEMENT_NOT_DECLARED), // [2]
 				d(5, 4, 12, DTDErrorCode.MSG_ELEMENT_NOT_DECLARED), // [3]
-				d(5, 4, 5, 21, XMLSyntaxErrorCode.ETagRequired)); // [4]
+				d(5, 4, 12, XMLSyntaxErrorCode.ETagRequired)); // [4]
 	}
 
 	@Test
@@ -651,7 +651,7 @@ public class DTDDiagnosticsTest {
 		XMLAssert.testDiagnosticsFor(xml, d(1, 33, 1, 50, DTDErrorCode.dtd_not_found), // [1]
 				d(2, 1, 12, DTDErrorCode.MSG_ELEMENT_NOT_DECLARED), // [2]
 				d(5, 4, 12, DTDErrorCode.MSG_ELEMENT_NOT_DECLARED), // [3]
-				d(5, 4, 5, 21, XMLSyntaxErrorCode.ETagRequired)); // [4]
+				d(5, 4, 12, XMLSyntaxErrorCode.ETagRequired)); // [4]
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -38,7 +38,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * AttributeNotUnique tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/AttributeNotUnique
 	 * @throws Exception
 	 */
@@ -56,7 +56,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * AttributeNSNotUnique tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/AttributeNSNotUnique
 	 * @throws Exception
 	 */
@@ -85,7 +85,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ContentIllegalInProlog tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ContentIllegalInProlog
 	 * @throws Exception
 	 */
@@ -97,7 +97,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ContentIllegalInProlog tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ContentIllegalInProlog
 	 * @throws Exception
 	 */
@@ -109,7 +109,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ContentIllegalInProlog tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ContentIllegalInProlog
 	 * @throws Exception
 	 */
@@ -127,7 +127,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * DashDashInComment tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/DashDashInComment
 	 * @throws Exception
 	 */
@@ -141,7 +141,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ElementUnterminated tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ElementUnterminated
 	 * @throws Exception
 	 */
@@ -218,7 +218,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ElementPrefixUnbound tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ElementPrefixUnbound
 	 * @throws Exception
 	 */
@@ -233,7 +233,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * EmptyPrefixedAttName tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/EmptyPrefixedAttName
 	 * @throws Exception
 	 */
@@ -265,7 +265,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * ETagRequired tests
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ETagRequired * @throws
 	 *      Exception
 	 */
@@ -275,7 +275,7 @@ public class XMLSyntaxDiagnosticsTest {
 				"  		<Nm>Name\r\n" + //
 				"		</UltmtDbtr> \r\n" + //
 				"			</Nm>  ";
-		Diagnostic d = d(1, 5, 2, 2, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 5, 1, 7, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(1, 12, 1, 12, "</Nm>")));
 	}
@@ -285,7 +285,7 @@ public class XMLSyntaxDiagnosticsTest {
 		String xml = "<UltmtDbtr>\r\n" + //
 				"  		Nm>Name</Nm>\r\n" + //
 				"		</UltmtDbtr>";
-		testDiagnosticsFor(xml, d(0, 1, 1, 11, XMLSyntaxErrorCode.ETagRequired));
+		testDiagnosticsFor(xml, d(0, 1, 0, 10, XMLSyntaxErrorCode.ETagRequired));
 	}
 
 	@Test
@@ -295,7 +295,7 @@ public class XMLSyntaxDiagnosticsTest {
 				"    <Ad>\r\n" + //
 				"    <Ph>\r\n" + //
 				"</UltmtDbtr>";
-		Diagnostic d = d(3, 5, 4, 0, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(3, 5, 3, 7, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 8, 3, 8, "</Ph>")));
 	}
@@ -305,7 +305,7 @@ public class XMLSyntaxDiagnosticsTest {
 		String xml = "<a>\r\n" + //
 				"	<b>\r\n" + //
 				"		</c>";
-		Diagnostic d = d(1, 2, 2, 2, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 2, 1, 3, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, //
 				ca(d, te(2, 4, 2, 5, "b")), ca(d, te(2, 6, 2, 6, "\r\n	</b>")));
@@ -316,7 +316,7 @@ public class XMLSyntaxDiagnosticsTest {
 		String xml = "<root>\r\n" + //
 				"<ABC>def\r\n" + //
 				"</root>";
-		Diagnostic d = d(1, 1, 2, 0, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 1, 1, 4, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(1, 8, 1, 8, "</ABC>")));
 	}
@@ -327,7 +327,7 @@ public class XMLSyntaxDiagnosticsTest {
 				"	<foo>\r\n" + //
 				"		</\r\n" + //
 				"</root>";
-		Diagnostic d = d(1, 2, 2, 2, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 2, 1, 5, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(2, 4, 2, 4, "foo>")));
 	}
@@ -339,7 +339,7 @@ public class XMLSyntaxDiagnosticsTest {
 				"		</\r\n" + //
 				"	</foo>\r\n" + //
 				"</root>";
-		Diagnostic d = d(1, 2, 2, 2, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 2, 1, 5, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(2, 2, 2, 4, "")));
 	}
@@ -351,14 +351,14 @@ public class XMLSyntaxDiagnosticsTest {
 				"		</bar>\r\n" + //
 				"	</foo>\r\n" + //
 				"</root>";
-		Diagnostic d = d(1, 2, 2, 2, XMLSyntaxErrorCode.ETagRequired);
+		Diagnostic d = d(1, 2, 1, 5, XMLSyntaxErrorCode.ETagRequired);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(2, 2, 2, 8, "")));
 	}
 
 	/**
 	 * Test ETagUnterminated
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ETagUnterminated
 	 * @throws Exception
 	 */
@@ -373,7 +373,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * Test ETagUnterminated
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ETagUnterminated
 	 * @throws Exception
 	 */
@@ -391,7 +391,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * Test ETagUnterminated
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ETagUnterminated
 	 * @throws Exception
 	 */
@@ -405,7 +405,7 @@ public class XMLSyntaxDiagnosticsTest {
 
 	/**
 	 * Test ETagUnterminated
-	 * 
+	 *
 	 * @see https://wiki.xmldation.com/Support/Validator/ETagUnterminated
 	 * @throws Exception
 	 */
@@ -449,7 +449,7 @@ public class XMLSyntaxDiagnosticsTest {
 				+ //
 				"<CstmrCdtTrfInitn>\r\n" + //
 				"</CstmrCdtTrfInitn>";
-		Diagnostic d = d(1, 1, 3, 19, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(1, 1, 1, 9, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 19, 3, 19, "\r\n</Document>")));
 	}
@@ -457,7 +457,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatch2() throws Exception {
 		String xml = "<ABC>";
-		Diagnostic d = d(0, 1, 0, 5, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 5, 0, 5, "</ABC>")));
 	}
@@ -465,7 +465,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatch3() throws Exception {
 		String xml = "<";
-		Diagnostic d = d(0, 0, 0, 1, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 1, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d); // no code actions
 	}
@@ -473,7 +473,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatch4() throws Exception {
 		String xml = "<?";
-		Diagnostic d = d(0, 0, 0, 2, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 1, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 	}
 
@@ -510,7 +510,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatchWithAttributes() throws Exception {
 		String xml = "<ABC a=''   ";
-		Diagnostic d = d(0, 1, 0, 9, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, //
 				ca(d, te(0, 9, 0, 9, "/>")), //
@@ -529,7 +529,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatchWithText() throws Exception {
 		String xml = "<ABC>def";
-		Diagnostic d = d(0, 1, 0, 8, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 8, 0, 8, "</ABC>")));
 	}
@@ -537,7 +537,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testMarkupEntityMismatchWithTextAndNewLine() throws Exception {
 		String xml = "<ABC>def\r\n";
-		Diagnostic d = d(0, 1, 0, 8, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 8, 0, 8, "</ABC>")));
 	}
@@ -546,7 +546,7 @@ public class XMLSyntaxDiagnosticsTest {
 	public void testMarkupEntityMismatchMultiLine() throws Exception {
 		String xml = "<foo action=\"toot\"\r\n" + //
 				"		    /";
-		Diagnostic d = d(0, 1, 1, 7, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		Diagnostic d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, //
 				te(1, 7, 1, 7, ">")));
@@ -765,12 +765,12 @@ public class XMLSyntaxDiagnosticsTest {
 				ca(d, te(0, 2, 0, 2, "></a>")));
 
 		xml = "<a>";
-		d = d(0, 1, 0, 3, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		d = d(0, 1, 0, 2, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 3, 0, 3, "</a>")));
 
 		xml = "<a /";
-		d = d(0, 1, 0, 4, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		d = d(0, 1, 0, 2, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 4, 0, 4, ">")));
 
@@ -780,7 +780,7 @@ public class XMLSyntaxDiagnosticsTest {
 		testCodeActionsFor(xml, d, ca(d, te(0, 4, 0, 4, ">")));
 
 		xml = "<a></";
-		d = d(0, 1, 0, 3, XMLSyntaxErrorCode.MarkupEntityMismatch);
+		d = d(0, 1, 0, 2, XMLSyntaxErrorCode.MarkupEntityMismatch);
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(0, 5, 0, 5, "a>")));
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxRelatedInfoFinderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxRelatedInfoFinderTest.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel;
+
+import static org.eclipse.lemminx.XMLAssert.d;
+import static org.eclipse.lemminx.XMLAssert.l;
+import static org.eclipse.lemminx.XMLAssert.r;
+
+import java.util.Arrays;
+
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
+import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticRelatedInformation;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
+import org.junit.jupiter.api.Test;
+
+public class XMLSyntaxRelatedInfoFinderTest {
+
+	final String XML_FILE_PATH = "src/test/resources/test.xml";
+
+	@Test
+	public void eTagRequiredWithoutRelatedInfo() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot>\n" + //
+				"</root>";
+
+				Diagnostic diagnostic = d(1, 3, 1, 7,
+				XMLSyntaxErrorCode.ETagRequired,
+				"The element type \"boot\" must be terminated by the matching end-tag \"</boot>\".");
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		XMLValidationSettings validationSettings = new XMLValidationSettings();
+		validationSettings.setNoGrammar("ignore");
+		ContentModelSettings settings = new ContentModelSettings();
+		settings.setValidation(validationSettings);
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, XML_FILE_PATH, false,
+				settings, //
+				diagnostic);
+	}
+
+	@Test
+	public void eTagRequiredRelatedInfo() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot>\n" + //
+				"</root>";
+
+		Diagnostic diagnostic = d(1, 3, 1, 7,
+				XMLSyntaxErrorCode.ETagRequired,
+				"The element type \"boot\" must be terminated by the matching end-tag \"</boot>\".");
+		diagnostic.setRelatedInformation(Arrays.asList(
+			new DiagnosticRelatedInformation(l(XML_FILE_PATH, r(2, 0, 2, 0)), "")
+		));
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void eTagRequiredIncompleteClosing1RelatedInfo() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot></\n" + //
+				"</root>";
+
+		Diagnostic diagnostic = d(1, 3, 1, 7,
+				XMLSyntaxErrorCode.ETagRequired,
+				"The element type \"boot\" must be terminated by the matching end-tag \"</boot>\".");
+		diagnostic.setRelatedInformation(Arrays.asList(
+			new DiagnosticRelatedInformation(l(XML_FILE_PATH, r(1, 10, 1, 10)), "")
+		));
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void eTagRequiredIncompleteClosing2RelatedInfo() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot></boo\n" + //
+				"</root>";
+
+		Diagnostic diagnostic = d(1, 3, 1, 7,
+				XMLSyntaxErrorCode.ETagRequired,
+				"The element type \"boot\" must be terminated by the matching end-tag \"</boot>\".");
+		diagnostic.setRelatedInformation(Arrays.asList(
+			new DiagnosticRelatedInformation(l(XML_FILE_PATH, r(2, 0, 2, 0)), "")
+		));
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void eTagUnterminatedNoRelatedInfo() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot></boot\n" + //
+				"</root>";
+
+		Diagnostic diagnostic = d(1, 10, 1, 14,
+				XMLSyntaxErrorCode.ETagUnterminated,
+				"The end-tag for element type \"boot\" must end with a '>' delimiter.");
+
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void markupEntityMismatchRelatedInfoWithNestedElement() {
+		String xml = //
+				"<root>\n" + //
+				"  <boot>";
+
+		Diagnostic diagnostic = d(0, 1, 0, 5,
+				XMLSyntaxErrorCode.MarkupEntityMismatch,
+				"XML document structures must start and end within the same entity.");
+		diagnostic.setRelatedInformation(Arrays.asList(
+			new DiagnosticRelatedInformation(l(XML_FILE_PATH, r(1, 8, 1, 8)), "")
+		));
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void markupEntityMismatchRelatedInfoWithAttributes() {
+		String xml = //
+				"<root aaa='bbb' ccc='ddd'";
+
+		Diagnostic diagnostic = d(0, 1, 0, 5,
+				XMLSyntaxErrorCode.MarkupEntityMismatch,
+				"XML document structures must start and end within the same entity.");
+		diagnostic.setRelatedInformation(Arrays.asList(
+			new DiagnosticRelatedInformation(l(XML_FILE_PATH, r(0, 25, 0, 25)), "")
+		));
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	@Test
+	public void markupEntityMismatchRelatedInfoWithBrokenClosingTag() {
+		String xml = //
+				"<root>\n" + //
+				"  \n" + //
+				"</root";
+
+		Diagnostic diagnostic = d(2, 2, 2, 6,
+				XMLSyntaxErrorCode.MarkupEntityMismatch,
+				"XML document structures must start and end within the same entity.");
+		diagnostic.setSeverity(DiagnosticSeverity.Error);
+		diagnostic.setSource("xml");
+
+		assertDiagnosticsWithRelatedInfo(xml, diagnostic);
+	}
+
+	private void assertDiagnosticsWithRelatedInfo(String xml, Diagnostic diagnostic) {
+		XMLValidationSettings validationSettings = new XMLValidationSettings();
+		validationSettings.setNoGrammar("ignore");
+		validationSettings.setCapabilities(new PublishDiagnosticsCapabilities(true));
+		ContentModelSettings settings = new ContentModelSettings();
+		settings.setValidation(validationSettings);
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, XML_FILE_PATH, false,
+				settings, //
+				diagnostic);
+	}
+
+}


### PR DESCRIPTION
Revert MarkupEntityMismatch and ETagRequired error ranges so they only
cover the start tag element name.

Keep existing CodeAction behaviour intact.

If the client supports DiagnosticRelatedInformation, add the expected
location of the close tag as related info to MarkupEntityMismatch and
ETagRequired errors.

Closes #963